### PR TITLE
Empty response body handled

### DIFF
--- a/app/src/main/java/io/xavier/topwsb/data/remote/dto/intraday_data/IntradayDataDto.kt
+++ b/app/src/main/java/io/xavier/topwsb/data/remote/dto/intraday_data/IntradayDataDto.kt
@@ -12,5 +12,5 @@ data class IntradayDataDto(
     @SerializedName("Meta Data")
     val metaData: MetaDataDto,
     @SerializedName("Time Series (30min)")
-    val timeSeries: Map<String, IntradayDataPointDto>
+    val timeSeries: Map<String, IntradayDataPointDto>?
 )

--- a/app/src/main/java/io/xavier/topwsb/data/repository/IntradayDataRepositoryImpl.kt
+++ b/app/src/main/java/io/xavier/topwsb/data/repository/IntradayDataRepositoryImpl.kt
@@ -2,6 +2,7 @@ package io.xavier.topwsb.data.repository
 
 import io.xavier.topwsb.BuildConfig
 import io.xavier.topwsb.data.remote.StockDataApi
+import io.xavier.topwsb.domain.exceptions.ApiException
 import io.xavier.topwsb.domain.mapper.toIntradayData
 import io.xavier.topwsb.domain.model.chart_data.IntradayData
 import io.xavier.topwsb.domain.repository.IntradayDataRepository
@@ -13,9 +14,15 @@ class IntradayDataRepositoryImpl @Inject constructor(
     private val stockDataApi: StockDataApi
 ) : IntradayDataRepository {
     override suspend fun getIntradayData(ticker: String): IntradayData {
-        return stockDataApi.getIntradayData(
+        val data = stockDataApi.getIntradayData(
             apiKey = BuildConfig.API_KEY_ALPHA_ADVANTAGE,
             ticker = ticker
-        ).toIntradayData()
+        )
+
+        if (data.timeSeries.isNullOrEmpty()) {
+            throw ApiException("Unable to fetch timeseries data.")
+        }
+
+        return data.toIntradayData()
     }
 }

--- a/app/src/main/java/io/xavier/topwsb/domain/exceptions/ApiException.kt
+++ b/app/src/main/java/io/xavier/topwsb/domain/exceptions/ApiException.kt
@@ -1,0 +1,11 @@
+package io.xavier.topwsb.domain.exceptions
+
+/**
+ * Exception thrown when an API returns an empty result, but still has a status HTTP status code of
+ * 200. This was observed to be happening with the Alpha Advantage API when requesting intraday
+ * time-series data for some tickers.
+ * For more details see https://github.com/xmcnulty/wsb-trendies/issues/22
+ *
+ * @author xmcnulty
+ */
+class ApiException(message: String) : Exception(message)

--- a/app/src/main/java/io/xavier/topwsb/domain/mapper/IntradayDataMapper.kt
+++ b/app/src/main/java/io/xavier/topwsb/domain/mapper/IntradayDataMapper.kt
@@ -32,7 +32,7 @@ fun IntradayDataPointDto.toChartDataPoint(
  * @return [IntradayData]
  */
 fun IntradayDataDto.toIntradayData(): IntradayData {
-    val dataPoints = timeSeries.map { entry ->
+    val dataPoints = timeSeries!!.map { entry ->
         entry.value.toChartDataPoint(entry.key)
     }
 

--- a/app/src/main/java/io/xavier/topwsb/domain/repository/IntradayDataRepository.kt
+++ b/app/src/main/java/io/xavier/topwsb/domain/repository/IntradayDataRepository.kt
@@ -1,5 +1,6 @@
 package io.xavier.topwsb.domain.repository
 
+import io.xavier.topwsb.domain.exceptions.ApiException
 import io.xavier.topwsb.domain.model.chart_data.IntradayData
 
 /**
@@ -16,6 +17,9 @@ interface IntradayDataRepository {
      *
      * @param ticker stock ticker
      * @return [IntradayData]
+     *
+     * @throws [ApiException] if Api response contains no intraday data
      */
+    @Throws(ApiException::class)
     suspend fun getIntradayData(ticker: String): IntradayData
 }

--- a/app/src/main/java/io/xavier/topwsb/domain/use_case/stock_details/GetIntradayDataUseCase.kt
+++ b/app/src/main/java/io/xavier/topwsb/domain/use_case/stock_details/GetIntradayDataUseCase.kt
@@ -1,6 +1,7 @@
 package io.xavier.topwsb.domain.use_case.stock_details
 
 import io.xavier.topwsb.common.Resource
+import io.xavier.topwsb.domain.exceptions.ApiException
 import io.xavier.topwsb.domain.model.chart_data.IntradayData
 import io.xavier.topwsb.domain.repository.IntradayDataRepository
 import retrofit2.HttpException
@@ -26,6 +27,8 @@ class GetIntradayDataUseCase @Inject constructor(
             emit(Resource.Error(e.localizedMessage ?: "An unexpected error occurred"))
         } catch (e: IOException) {
             emit(Resource.Error("Couldn't reach server. Check your internet connection"))
+        } catch (e: ApiException) {
+            emit(Resource.Error(e.localizedMessage ?: "Api Error"))
         }
     }
 }


### PR DESCRIPTION
Added check for empty time-series response from the alpha advantage api. If this occurs a ApiException.kt is thrown. Briefly tested. Extensive testing will be done when tests are implemented prior to release. Merge of this issue closes #22 